### PR TITLE
[Fixes #9] Better logging for auth failures

### DIFF
--- a/jwt-opa/src/main/java/com/alertavert/opa/configuration/RoutesConfiguration.java
+++ b/jwt-opa/src/main/java/com/alertavert/opa/configuration/RoutesConfiguration.java
@@ -58,6 +58,7 @@ public class RoutesConfiguration {
   private final RoutesProperties properties;
 
   @PostConstruct public void log() {
-    log.warn("Routes: {}", properties);
+    log.info("Routes configured: allowed = {}, authenticated = {}",
+        properties.allowed, properties.authenticated);
   }
 }

--- a/jwt-opa/src/main/java/com/alertavert/opa/jwt/JwtAuthenticationWebFilter.java
+++ b/jwt-opa/src/main/java/com/alertavert/opa/jwt/JwtAuthenticationWebFilter.java
@@ -69,7 +69,7 @@ public class JwtAuthenticationWebFilter implements WebFilter {
         this.authenticationConverter.convert(exchange)
             .doOnNext(authentication -> {
               Principal principal = (Principal) authentication.getPrincipal();
-              log.debug("Validated API Token for Principal: `{}`", principal.getName());
+              log.debug("---Validated API Token for Principal: `{}`", principal.getName());
             })
             .switchIfEmpty(chain.filter(exchange).then(Mono.empty()))
 
@@ -85,8 +85,8 @@ public class JwtAuthenticationWebFilter implements WebFilter {
 
   private Mono<Void> onAuthenticationSuccess(Authentication authentication,
                                              WebFilterExchange filterExchange) {
-    log.debug("Auth Success :: {}", authentication == null ? "null" :
-        authentication.getCredentials());
+    log.debug("Auth success, principal = `{}`", authentication == null ? "null" :
+        authentication.getPrincipal());
 
     SecurityContextImpl securityContext = new SecurityContextImpl();
     securityContext.setAuthentication(authentication);

--- a/jwt-opa/src/main/java/com/alertavert/opa/jwt/JwtTokenProvider.java
+++ b/jwt-opa/src/main/java/com/alertavert/opa/jwt/JwtTokenProvider.java
@@ -27,8 +27,10 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.alertavert.opa.configuration.KeyProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.User;
@@ -117,15 +119,15 @@ public class JwtTokenProvider {
       List<? extends  GrantedAuthority> authorities = AuthorityUtils.createAuthorityList(
           decodedJWT.getClaim(ROLES).asArray(String.class));
 
+      log.debug("Token is valid: subject = `{}`, authorities = `{}`", subject, authorities);
+
       // We do not store the password here, as we do not need it (by virtue of the API Token
       // having been successfully verified, we know the user is authenticated).
-      // TODO: should we allow client applications to retrieve/inject it here?
       User principal = new User(subject, "", authorities);
       return new UsernamePasswordAuthenticationToken(principal, token, authorities);
-
     } catch (Exception error) {
-      log.error("Could not authenticate Token: {}", error.getMessage());
+      log.warn("Could not authenticate Token: {}", error.getMessage());
+      throw new BadCredentialsException("JWT invalid", error);
     }
-    return null;
   }
 }

--- a/jwt-opa/src/main/java/com/alertavert/opa/jwt/ServerTokenAuthenticationConverter.java
+++ b/jwt-opa/src/main/java/com/alertavert/opa/jwt/ServerTokenAuthenticationConverter.java
@@ -31,6 +31,7 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import static com.alertavert.opa.Constants.BEARER_TOKEN;
+import static com.alertavert.opa.Constants.TOKEN_MISSING_OR_INVALID;
 
 /**
  * <h2>ServerTokenAuthenticationConverter</h2>
@@ -55,7 +56,7 @@ public class ServerTokenAuthenticationConverter implements ServerAuthenticationC
         && bearerToken.length() > BEARER_TOKEN.length()) {
       return Mono.just(bearerToken.substring(BEARER_TOKEN.length() + 1));
     }
-    log.warn(Constants.TOKEN_MISSING_OR_INVALID);
+    log.debug(TOKEN_MISSING_OR_INVALID);
     return Mono.empty();
   }
 

--- a/jwt-opa/src/test/java/com/alertavert/opa/JwtTokenProviderTest.java
+++ b/jwt-opa/src/test/java/com/alertavert/opa/JwtTokenProviderTest.java
@@ -27,6 +27,7 @@ import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -137,6 +138,7 @@ class JwtTokenProviderTest extends AbstractTestBase {
 
   @Test
   public void invalidTokenFailsAuthentication() {
-    assertThat(provider.getAuthentication("definitelynotatoken")).isNull();
+    assertThrows(AuthenticationException.class,
+        () -> provider.getAuthentication("definitelynotatoken"));
   }
 }

--- a/jwt-opa/src/test/java/com/alertavert/opa/jwt/ServerTokenAuthenticationConverterTest.java
+++ b/jwt-opa/src/test/java/com/alertavert/opa/jwt/ServerTokenAuthenticationConverterTest.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.server.ServerWebExchange;
 
@@ -34,6 +35,7 @@ import java.security.Principal;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -73,9 +75,9 @@ class ServerTokenAuthenticationConverterTest extends AbstractTestBase {
 
   @Test
   public void invalidTokenShouldFail() {
-    setBearerTokenForRequest(request, "definitelynotatoken");
-    Authentication authentication = converter.convert(exchange).block();
-    assertThat(authentication).isNull();
+    setBearerTokenForRequest(request, "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJhZ"
+        + "pbiIsInJvbGVzIjpbIlNZU1RFTSJdLCJpc3MiOiJkZW1vLWlzc3VlciIsImV4cCI6MTY0MjgzNjY2MywiaWF0");
+    assertThrows(AuthenticationException.class, () -> converter.convert(exchange).block());
   }
 
   @Test

--- a/jwt-opa/src/test/java/com/alertavert/opa/security/ApiTokenAuthenticationTest.java
+++ b/jwt-opa/src/test/java/com/alertavert/opa/security/ApiTokenAuthenticationTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 
 import java.security.Principal;
@@ -92,13 +93,13 @@ class ApiTokenAuthenticationTest extends AbstractTestBase {
 
   @Test
   void isAuthenticatedFailsForBogus() {
-    Authentication invalid = factory.createAuthentication(
+    assertThrows(AuthenticationException.class, () -> factory.createAuthentication(
         token.replace("s", "5").replace("e", "3")
-    ).block();
-    assertThat(invalid).isNull();
+    ).block());
 
-    invalid = factory.createAuthentication("bogus secret and a half").block();
-    assertThat(invalid).isNull();
+    assertThrows(AuthenticationException.class, () -> factory.createAuthentication(
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsInJvbGVzIjpbIlNZU1"
+            + "RFTSJdLCJpc3MiOiJkZW1vLWlzc3VlciIsImV4cCI6MTY0MjgzNjY2MywiaWF0").block());
   }
 
   @Test

--- a/webapp-example/src/main/resources/application.yaml
+++ b/webapp-example/src/main/resources/application.yaml
@@ -52,7 +52,7 @@ tokens:
   # security requirements.
   should_expire: true
   # For the demo app, we make the API Token valid for 5 minutes.
-  expires_after_sec: 300
+  expires_after_sec: 30
 
   # Interval in seconds, after creation, during which the JWT is not valid.
   # Corresponds to the `nbf` ("not before") claim.


### PR DESCRIPTION
Also throwing an AuthenticationException which is the idiomatic way
to signal authentication failures in Spring Security.